### PR TITLE
Add WTF message to list of ignored level values

### DIFF
--- a/lib/src/entity/log.dart
+++ b/lib/src/entity/log.dart
@@ -86,6 +86,8 @@ class Log {
             Level.nothing,
             // ignore: deprecated_member_use
             Level.verbose,
+            // ignore: deprecated_member_use
+            Level.wtf,
           ].contains(l))
       .toList();
 }


### PR DESCRIPTION
When clearing logs, an extra WTF log type action chip appears. When clicking on the action chip (or any other action chip) it disappears, making it likely that this is a bug.

In the Log class located in lib/src/entity/log.dart there is an attribute called usedLevelValues. In it there is a list of excluded log values which are not to be printed to the screen as Action chips. However, when using the LoggerScreenPrinter.clear() method, the level count map is checked using this Log.usedLevelValues attribute, which was missing an excluder for the WTF message type.

Now that the Level.wtf has been added to the list of excluded levels, the WTF message no longer appears when clearing the logs.